### PR TITLE
GET endpoint to browse resources

### DIFF
--- a/src/Database.Entities/DbResource.cs
+++ b/src/Database.Entities/DbResource.cs
@@ -16,6 +16,6 @@ public class DbResource : TenantEntity
 
     [Required]
     [MaxLength(500)]
-    [Column("file_path")]
-    public required string FilePath { get; set; }
+    [Column("file_name")]
+    public required string Filename { get; set; }
 }

--- a/src/Database/Migrations/20251118191520_ResourceFilenames.Designer.cs
+++ b/src/Database/Migrations/20251118191520_ResourceFilenames.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Database.Migrations
 {
     [DbContext(typeof(OurDbContext))]
-    partial class OurDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251118191520_ResourceFilenames")]
+    partial class ResourceFilenames
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Database/Migrations/20251118191520_ResourceFilenames.cs
+++ b/src/Database/Migrations/20251118191520_ResourceFilenames.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class ResourceFilenames : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "file_path",
+                table: "resource",
+                newName: "file_name");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "file_name",
+                table: "resource",
+                newName: "file_path");
+        }
+    }
+}

--- a/src/Database/ResourceDao.cs
+++ b/src/Database/ResourceDao.cs
@@ -15,11 +15,11 @@ internal class ResourceDao : IResourceDao
         return _context.Resources.Query().SingleOrDefault(r => r.Guid == guid);
     }
 
-    public void SaveSingleResource(string filePath, string singleGroupName)
+    public void SaveSingleResource(string filename, string singleGroupName)
     {
         _context.ResourceMemberships.Add(new DbResourceMembership
         {
-            Resource = new DbResource { FilePath = filePath },
+            Resource = new DbResource { Filename = filename },
             Group = new DbResourceGroup
             {
                 IsSingle = true,

--- a/src/Database/ResourceDao.cs
+++ b/src/Database/ResourceDao.cs
@@ -15,6 +15,11 @@ internal class ResourceDao : IResourceDao
         return _context.Resources.Query().SingleOrDefault(r => r.Guid == guid);
     }
 
+    public IList<DbResource> GetAllResources()
+    {
+        return _context.Resources.Query().ToList();
+    }
+
     public void SaveSingleResource(string filename, string singleGroupName)
     {
         _context.ResourceMemberships.Add(new DbResourceMembership

--- a/src/Endpoints.Dto/ResourceDto.cs
+++ b/src/Endpoints.Dto/ResourceDto.cs
@@ -1,0 +1,7 @@
+namespace Endpoints.Dto;
+
+public class ResourceDto
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+}

--- a/src/Endpoints.Interfaces/IResourceService.cs
+++ b/src/Endpoints.Interfaces/IResourceService.cs
@@ -5,6 +5,7 @@ namespace Endpoints.Interfaces;
 
 public interface IResourceService
 {
+    IList<ResourceDto> GetResources(TutorRole role);
     ResourceUrlDto GetDownloadUrlForTutor(Guid externalResourceId, TutorRole role);
     ResourceUrlDto BeginUpload(string filename, TutorRole role);
 }

--- a/src/Endpoints/Resources/GetResourcesFunction.cs
+++ b/src/Endpoints/Resources/GetResourcesFunction.cs
@@ -1,0 +1,18 @@
+using Amazon.Lambda.APIGatewayEvents;
+using Endpoints.Interfaces.Authorization;
+
+namespace Endpoints.Resources;
+
+public class GetResourcesFunction
+{
+    public static async Task<APIGatewayProxyResponse> GetResources(
+        APIGatewayProxyRequest request)
+    {
+        return await RestIo.HandleRestBoilerplateAsync(request, async identity =>
+        {
+            var role = identity.RequireTutor();
+            var service = await ServiceFactory.CreateResourceServiceAsync(identity);
+            return service.GetResources(role);
+        });
+    }
+}

--- a/src/Services.Interfaces/IResourceDao.cs
+++ b/src/Services.Interfaces/IResourceDao.cs
@@ -5,5 +5,5 @@ namespace Services.Interfaces;
 public interface IResourceDao
 {
     DbResource? GetResourceByGuid(Guid guid);
-    void SaveSingleResource(string filePath, string singleGroupName);
+    void SaveSingleResource(string filename, string singleGroupName);
 }

--- a/src/Services.Interfaces/IResourceDao.cs
+++ b/src/Services.Interfaces/IResourceDao.cs
@@ -5,5 +5,6 @@ namespace Services.Interfaces;
 public interface IResourceDao
 {
     DbResource? GetResourceByGuid(Guid guid);
+    IList<DbResource> GetAllResources();
     void SaveSingleResource(string filename, string singleGroupName);
 }

--- a/src/Services/ResourceService.cs
+++ b/src/Services/ResourceService.cs
@@ -14,6 +14,16 @@ public class ResourceService : IResourceService
         _fileStorage = fileStorage;
     }
 
+    public IList<ResourceDto> GetResources(TutorRole role)
+    {
+        using var t = _transactor.BeginTransaction();
+        return t.ResourceDao.GetAllResources().Select(r => new ResourceDto
+        {
+            Id = r.Guid.ToString(),
+            Name = r.Filename,
+        }).ToList();
+    }
+
     public ResourceUrlDto GetDownloadUrlForTutor(Guid externalResourceId, TutorRole role)
     {
         using var t = _transactor.BeginTransaction();

--- a/src/Services/ResourceService.cs
+++ b/src/Services/ResourceService.cs
@@ -20,28 +20,30 @@ public class ResourceService : IResourceService
         var resource = t.ResourceDao.GetResourceByGuid(externalResourceId);
         return new ResourceUrlDto
         {
-            Url = GetDownloadUrl(resource),
+            Url = GetDownloadUrl(resource, t),
         };
     }
 
-    private string? GetDownloadUrl(DbResource? resource)
+    private string? GetDownloadUrl(DbResource? resource, ITransaction t)
     {
         if (resource == null)
             return null;
-        return _fileStorage.GetDownloadUrl(resource.FilePath);
+        return _fileStorage.GetDownloadUrl(GetFilePath(resource.Filename, t));
     }
 
     public ResourceUrlDto BeginUpload(string filename, TutorRole role)
     {
         using var t = _transactor.BeginTransaction();
-        var tutor = t.TutorDao.GetTutor();
-        var filePath = $"{tutor.ResourcePathPrefix}/{filename}";
-        t.ResourceDao.SaveSingleResource(filePath, $"(single) {filename}");
+        var url = _fileStorage.GetUploadUrl(GetFilePath(filename, t));
+        t.ResourceDao.SaveSingleResource(filename, $"(single) {filename}");
         t.Commit();
-        return new ResourceUrlDto
-        {
-            Url = _fileStorage.GetUploadUrl(filePath),
-        };
+        return new ResourceUrlDto { Url = url };
+    }
+
+    private static string GetFilePath(string filename, ITransaction t)
+    {
+        var tutor = t.TutorDao.GetTutor();
+        return $"{tutor.ResourcePathPrefix}/{filename}";
     }
 
     private readonly IFileStorageClient _fileStorage;

--- a/template.yaml
+++ b/template.yaml
@@ -599,6 +599,24 @@ Resources:
             Method: post
             RestApiId: !Ref KorepetycjeApi
 
+  GetResources:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src/Endpoints/
+      Handler: Endpoints::Endpoints.Resources.GetResourcesFunction::GetResources
+      Runtime: dotnet8
+      Architectures:
+        - x86_64
+      MemorySize: 512
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Events:
+        GetLessons:
+          Type: Api
+          Properties:
+            Path: /api/resource/list
+            Method: get
+            RestApiId: !Ref KorepetycjeApi
+
   DownloadResource:
     Type: AWS::Serverless::Function
     Properties:

--- a/test/Services.Tests/ResourceServiceTests.cs
+++ b/test/Services.Tests/ResourceServiceTests.cs
@@ -24,7 +24,7 @@ public class ResourceServiceTests
     {
         A.CallTo(() => _resourceDao.GetResourceByGuid(_resourceGuid)).Returns(new DbResource
         {
-            FilePath = "tutor/resource_name",
+            Filename = "resource_name",
         });
         A.CallTo(() => _fileStorage.GetDownloadUrl("tutor/resource_name"))
             .Returns("protocol://tutor/resource_name");
@@ -47,7 +47,7 @@ public class ResourceServiceTests
             .Returns("protocol://tutor/geometry.pdf");
         var dto = _service.BeginUpload("geometry.pdf", new TutorRole());
         A.CallTo(() => _resourceDao.SaveSingleResource(
-                "tutor/geometry.pdf", "(single) geometry.pdf"))
+                "geometry.pdf", "(single) geometry.pdf"))
             .MustHaveHappenedOnceExactly();
         A.CallTo(() => _transaction.Commit()).MustHaveHappenedOnceExactly();
         Assert.Equal("protocol://tutor/geometry.pdf", dto.Url);


### PR DESCRIPTION
Uwaga: migracja bazy danych zmienia nazwę resource.file_path na resource.file_name bez zmiany zawartości. Migrując trzeba jeszcze ręcznie usunąć prefiksy i slashe z tej kolumny, aby dotychczasowe zasoby działały.

Kod odpalony razem z frontendem.